### PR TITLE
implement improved node spacing zooming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ MaterialNet
 MaterialNet is a visual exploration tool to explore large networks in the context of material science.
 
 
+Interactions
+------------
+
+* Use the `mouse wheel` to zoom into the map
+* Use `ctrl + mouse wheel` to change the node spacing factor
+* `Clicking` on a node will select it, clicking on the same node again will deselect it
+
 
 
 Internal Notes

--- a/src/components/graph-vis/controls.js
+++ b/src/components/graph-vis/controls.js
@@ -76,6 +76,7 @@ class Controls extends React.Component {
               <SliderControl
                 value={store.spacing}
                 range={store.spacingRange}
+                step={0.1}
                 label={'Node spacing'}
                 onChange={(val) => { store.spacing = val; }}
               />

--- a/src/components/graph-vis/index.js
+++ b/src/components/graph-vis/index.js
@@ -14,6 +14,10 @@ class GraphVisComponent extends Component {
   visElement;
   scene = new GeoJSSceneManager({
     onZoomChanged: (val) => this.context.zoom = val,
+    onNodeSpacingChanged: (delta) => {
+      const next = this.context.spacing + (delta > 0 ? -0.1 : 0.1);
+      this.context.spacing = Math.max(next, Math.min(this.context.spacingRange[1], this.context.spacingRange[0]));
+    },
     picked: (node, position) => {
       this.context.selectNode(node, position);
     },


### PR DESCRIPTION
base on #88 

closes #86 and closes #85

when changing the node size change the center of the map to the scaled old center. (either center of the map or the position under the mouse)