### PR TITLE
add highlighted edge layer

### DIFF
--- a/src/components/graph-vis/index.js
+++ b/src/components/graph-vis/index.js
@@ -63,7 +63,7 @@ class GraphVisComponent extends Component {
     });
     setAndObserve(() => {
       this.scene.setLinkOpacity(store.opacity);
-    });
+    }, { delay: 250 }); // debounce
     setAndObserve(() => {
       this.scene.setData(store.filteredNodeNames, store.filteredEdges);
     }, { delay: 250 }); // debounce

--- a/src/components/graph-vis/index.js
+++ b/src/components/graph-vis/index.js
@@ -79,16 +79,7 @@ class GraphVisComponent extends Component {
       }
     });
     setAndObserve(() => {
-      if (store.pinnedNodes.length > 0) {
-        this.scene.displayFocus(store.pinnedNodes.map((d) => d.name), store.selected ? store.selected.name : null);
-        return;
-      }
-      // no pinned nodes, default behavior
-      if (store.selected == null) {
-        this.scene.undisplay();
-      } else {
-        this.scene.display(store.selected.name);
-      }
+      this.scene.display(store.selected ? store.selected.name : null, store.pinnedNodes.map((d) => d.name));
     });
     setAndObserve(() => {
       this.scene.linksVisible(store.showLinks);

--- a/src/data-provider/index.js
+++ b/src/data-provider/index.js
@@ -83,19 +83,6 @@ export class DiskDataProvider extends DataProvider {
     return val;
   }
 
-  neighborsOf(nodeNameOrSet) {
-    const lookup = typeof nodeNameOrSet === 'string' ? new Set([nodeNameOrSet]) : nodeNameOrSet;
-    // Collect neighborhood of selected node.
-    const onehop = new Set(lookup);
-    for (const edge of this.edges) {
-      if (lookup.has(edge[0]) || lookup.has(edge[1])) {
-        onehop.add(edge[0]);
-        onehop.add(edge[1]);
-      }
-    }
-    return onehop;
-  }
-
   edgeNodes (idx) {
     const edge = this.edges[idx];
     return edge;

--- a/src/geojs-scene-manager/index.js
+++ b/src/geojs-scene-manager/index.js
@@ -215,8 +215,8 @@ export class GeoJSSceneManager {
       });
     }
 
-    this.points.modified();
-    this.lines.modified();
+    this.points.dataTime().modified();
+    this.lines.dataTime().modified();
     this.map.draw();
   }
 


### PR DESCRIPTION
based on #93 and #90 

closes #94

adds an extra layer for the highlighted edges. In most cases, the number of visible edges is way smaller than all edges. Thus, instead of rendering lines with 0 opacity, just don't render them. 

